### PR TITLE
Transform to add an agent's name into the message content

### DIFF
--- a/autogen/agentchat/contrib/capabilities/transforms.py
+++ b/autogen/agentchat/contrib/capabilities/transforms.py
@@ -448,7 +448,25 @@ class TextMessageCompressor:
 
 
 class TextMessageContentName:
-    """A transform for including the agent's name in the content of a message."""
+    """A transform for including the agent's name in the content of a message.
+
+    How to create and apply the transform:
+    # Imports
+    from autogen.agentchat.contrib.capabilities import transform_messages, transforms
+
+    # Create Transform
+    name_transform = transforms.TextMessageContentName(position="start", format_string="'{name}' said:\n")
+
+    # Create the TransformMessages
+    context_handling = transform_messages.TransformMessages(
+                transforms=[
+                    name_transform
+                ]
+            )
+
+    # Add it to an agent so when they run inference it will apply to the messages
+    context_handling.add_to_agent(my_agent)
+    """
 
     def __init__(
         self,
@@ -469,10 +487,8 @@ class TextMessageContentName:
                 excluded from compression. If False, messages that match the filter will be compressed.
         """
 
-        assert isinstance(position, str) and position is not None
-        assert position in ["start", "end"]
-        assert isinstance(format_string, str) and format_string is not None
-        assert "{name}" in format_string
+        assert isinstance(position, str) and position in ["start", "end"]
+        assert isinstance(format_string, str) and "{name}" in format_string
         assert isinstance(deduplicate, bool) and deduplicate is not None
 
         self._position = position


### PR DESCRIPTION
The recent addition of non-OpenAI client classes has expanded the utility of AutoGen to a lot of different models through other cloud providers as well as the ability to run it with local LLMs.

However, the `name` field on each message is removed as only OpenAI can accept and utilise that field.

This means that functionality, like the GroupChat's select speaker, isn't as effective as the LLM may not be able to determine which 'agent' belongs to each message.

This PR introduces a transform that can add an agent's name to the start or end of message's text content. As this is a transform, it isn't permanent and doesn't change the original message.

How it works:
```
from autogen.agentchat.contrib.capabilities import transform_messages, transforms

# Create a transform
name_transform = TextMessageContentName(position="start", format_string="'{name}' said:\n")

# Create the TransformMessages
context_handling = transform_messages.TransformMessages(
            transforms=[
                name_transform
            ]
        )

# Add it to an agent so when they run inference it will apply to the messages
context_handling.add_to_agent(my_agent)

# Example
# Messages before
[
        {"role": "system", "content": "I am the system."},
        {"role": "user", "name": "charlie", "content": "I think the sky is blue."},
        {"role": "user", "name": "mary", "content": "The sky is red."},
        {"role": "user", "name": "bob", "content": "The sky is crimson."},
    ]

# Messages going into LLM (where name is removed, non-OpenAI clients)
[
        {"role": "system", "content": "I am the system."},
        {"role": "user", "content": "'charlie' said:\nI think the sky is blue."},
        {"role": "user", "content": "'mary' said:\nThe sky is red."},
        {"role": "user", "content": "'bob' said:\nThe sky is crimson."},
    ]
```

**Documentation to be done.**

## Dependency

For the GroupChat select speaker to be able to utilise this, PR #2719 needs to be merged first.

## Why are these changes needed?

To provide the necessary name context for non-OpenAI inference.

## Related issue number

## Checks

- [X] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [X] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.

(3334)