### PR TITLE
Fix Anthropic system messages

### DIFF
--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -314,7 +314,7 @@ def oai_messages_to_anthropic_messages(params: Dict[str, Any]) -> list[dict[str,
     last_tool_result_index = -1
     for message in params["messages"]:
         if message["role"] == "system":
-            params["system"] = message["content"]
+            params["system"] = params.get("system", "") + (" " if "system" in params else "") + message["content"]
         else:
             # New messages will be added here, manage role alternations
             expected_role = "user" if len(processed_messages) % 2 == 0 else "assistant"

--- a/autogen/oai/anthropic.py
+++ b/autogen/oai/anthropic.py
@@ -314,7 +314,7 @@ def oai_messages_to_anthropic_messages(params: Dict[str, Any]) -> list[dict[str,
     last_tool_result_index = -1
     for message in params["messages"]:
         if message["role"] == "system":
-            params["system"] = params.get("system", "") + (" " if "system" in params else "") + message["content"]
+            params["system"] = params.get("system", "") + ("\n" if "system" in params else "") + message["content"]
         else:
             # New messages will be added here, manage role alternations
             expected_role = "user" if len(processed_messages) % 2 == 0 else "assistant"


### PR DESCRIPTION
At the moment if the set of messages for inference has more than one system message, only the last system message will be put into the Anthropic API `system` parameter.

During some testing of group chats I noticed there are multiple system messages for speaker selection in auto mode. So this meant the speaker selection was losing context and failing.

This PR simply concatenates the system messages together and it proves effective.

## Why are these changes needed?

Group Chat doesn't work effectively with Anthropic models when in auto mode without it.

## Related issue number

None raised.

## Checks

- [ ] I've included any doc changes needed for https://microsoft.github.io/autogen/. See https://microsoft.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.

(3392)