### PR TITLE
Updated development instructions inline with changed URLs

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -10,21 +10,21 @@ These configurations can be used with Codespaces and locally.
 
 - **Purpose**: This Dockerfile, i.e., `./Dockerfile`, is designed for basic setups. It includes common Python libraries and essential dependencies required for general usage of AutoGen.
 - **Usage**: Ideal for those just starting with AutoGen or for general-purpose applications.
-- **Building the Image**: Run `docker build -f ./Dockerfile -t autogen_base_img .` in this directory.
+- **Building the Image**: Run `docker build -f ./Dockerfile -t autogen_ai_base_img .` in this directory.
 - **Using with Codespaces**: `Code > Codespaces > Click on +` By default + creates a Codespace on the current branch.
 
 ### full
 
 - **Purpose**: This Dockerfile, i.e., `./full/Dockerfile` is for advanced features. It includes additional dependencies and is configured for more complex or feature-rich AutoGen applications.
 - **Usage**: Suited for advanced users who need the full range of AutoGen's capabilities.
-- **Building the Image**: Execute `docker build -f full/Dockerfile -t autogen_full_img .`.
+- **Building the Image**: Execute `docker build -f full/Dockerfile -t autogen_ai_full_img .`.
 - **Using with Codespaces**: `Code > Codespaces > Click on ...> New with options > Choose "full" as devcontainer configuration`. This image may require a Codespace with at least 64GB of disk space.
 
 ### dev
 
 - **Purpose**: Tailored for AutoGen project developers, this Dockerfile, i.e., `./dev/Dockerfile` includes tools and configurations aiding in development and contribution.
 - **Usage**: Recommended for developers who are contributing to the AutoGen project.
-- **Building the Image**: Run `docker build -f dev/Dockerfile -t autogen_dev_img .`.
+- **Building the Image**: Run `docker build -f dev/Dockerfile -t autogen_ai_dev_img .`.
 - **Using with Codespaces**: `Code > Codespaces > Click on ...> New with options > Choose "dev" as devcontainer configuration`. This image may require a Codespace with at least 64GB of disk space.
 - **Before using**: We highly encourage all potential contributors to read the [AutoGen Contributing](https://microsoft.github.io/autogen/docs/Contribute) page prior to submitting any pull requests.
 

--- a/.devcontainer/dev/Dockerfile
+++ b/.devcontainer/dev/Dockerfile
@@ -1,7 +1,7 @@
 # Basic setup
 FROM python:3.11-slim-bookworm
 
-# add git lhs to apt
+# add git lfs to apt
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
 
 # Update and install necessary packages
@@ -10,18 +10,18 @@ RUN apt-get update && apt-get -y update
 RUN apt-get install -y sudo git npm vim nano curl wget git-lfs
 
 # Setup a non-root user 'autogen' with sudo access
-RUN adduser --disabled-password --gecos '' autogen
+RUN adduser --home /home/autogen-ai --disabled-password --gecos '' autogen
 RUN adduser autogen sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER autogen
-WORKDIR /home/autogen
+WORKDIR /home/autogen-ai
 
 # Set environment variable
 # ENV OPENAI_API_KEY="{OpenAI-API-Key}"
 
 # Clone the AutoGen repository
-RUN git clone https://github.com/microsoft/autogen.git /home/autogen/autogen
-WORKDIR /home/autogen/autogen
+RUN git clone https://github.com/autogen-ai/autogen.git /home/autogen-ai/autogen
+WORKDIR /home/autogen-ai/autogen
 
 # Install AutoGen in editable mode with extra components
 RUN sudo pip install -e .[test,teachable,lmm,retrievechat,mathchat,blendsearch]
@@ -37,11 +37,11 @@ RUN yarn install --frozen-lockfile --ignore-engines
 
 RUN arch=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/) && \
     wget -q https://github.com/quarto-dev/quarto-cli/releases/download/v1.5.23/quarto-1.5.23-linux-${arch}.tar.gz && \
-    mkdir -p /home/autogen/quarto/ && \
-    tar -xzf quarto-1.5.23-linux-${arch}.tar.gz --directory /home/autogen/quarto/ && \
+    mkdir -p /home/autogen-ai/quarto/ && \
+    tar -xzf quarto-1.5.23-linux-${arch}.tar.gz --directory /home/autogen-ai/quarto/ && \
     rm quarto-1.5.23-linux-${arch}.tar.gz
 
-ENV PATH="${PATH}:/home/autogen/quarto/quarto-1.5.23/bin/"
+ENV PATH="${PATH}:/home/autogen-ai/quarto/quarto-1.5.23/bin/"
 
 # Exposes the Yarn port for Docusaurus
 EXPOSE 3000

--- a/.devcontainer/full/Dockerfile
+++ b/.devcontainer/full/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Setup a non-root user 'autogen' with sudo access
-RUN adduser --disabled-password --gecos '' autogen
+RUN adduser --home /home/autogen-ai --disabled-password --gecos '' autogen
 RUN adduser autogen sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER autogen
-WORKDIR /home/autogen
+WORKDIR /home/autogen-ai
 
 # Set environment variable if needed
 # ENV OPENAI_API_KEY="{OpenAI-API-Key}"

--- a/.devcontainer/studio/Dockerfile
+++ b/.devcontainer/studio/Dockerfile
@@ -10,7 +10,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/python:3.10
 #
 ENV DEBIAN_FRONTEND=noninteractive
 
-# add git lhs to apt
+# add git lfs to apt
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
 
 RUN apt-get update \

--- a/dotnet/website/docfx.json
+++ b/dotnet/website/docfx.json
@@ -61,7 +61,7 @@
       "_appFooter": "AutoGen for .NET",
       "_appFaviconPath": "images/ag.ico",
       "_gitContribute": {
-        "repo": "https://github.com/microsoft/autogen.git",
+        "repo": "https://github.com/autogen-ai/autogen.git",
         "branch": "dotnet"
       }
     },

--- a/samples/tools/autogenbench/scenarios/GAIA/Templates/SocietyOfMind/requirements.txt
+++ b/samples/tools/autogenbench/scenarios/GAIA/Templates/SocietyOfMind/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/microsoft/autogen.git@society_of_mind_gaia
+git+https://github.com/autogen-ai/autogen.git@society_of_mind_gaia
 pdfminer.six
 markdownify
 pathvalidate

--- a/website/docs/contributor-guide/docker.md
+++ b/website/docs/contributor-guide/docker.md
@@ -2,9 +2,9 @@
 
 For developers contributing to the AutoGen project, we offer a specialized Docker environment. This setup is designed to streamline the development process, ensuring that all contributors work within a consistent and well-equipped environment.
 
-## Autogen Developer Image (autogen_dev_img)
+## Autogen Developer Image (autogen_ai_dev_img)
 
-- **Purpose**: The `autogen_dev_img` is tailored for contributors to the AutoGen project. It includes a suite of tools and configurations that aid in the development and testing of new features or fixes.
+- **Purpose**: The `autogen_ai_dev_img` is tailored for contributors to the AutoGen project. It includes a suite of tools and configurations that aid in the development and testing of new features or fixes.
 - **Usage**: This image is recommended for developers who intend to contribute code or documentation to AutoGen.
 - **Forking the Project**: It's advisable to fork the AutoGen GitHub project to your own repository. This allows you to make changes in a separate environment without affecting the main project.
 - **Updating Dockerfile**: Modify your copy of `Dockerfile` in the `dev` folder as needed for your development work.
@@ -12,17 +12,17 @@ For developers contributing to the AutoGen project, we offer a specialized Docke
 
 ## Building the Developer Docker Image
 
-- To build the developer Docker image (`autogen_dev_img`), use the following commands:
+- To build the developer Docker image (`autogen_ai_dev_img`), use the following commands:
 
   ```bash
-  docker build -f .devcontainer/dev/Dockerfile -t autogen_dev_img https://github.com/microsoft/autogen.git#main
+  docker build -f .devcontainer/dev/Dockerfile -t autogen_ai_dev_img https://github.com/autogen-ai/autogen.git#main
   ```
 
 - For building the developer image built from a specific Dockerfile in a branch other than main/master
 
   ```bash
   # clone the branch you want to work out of
-  git clone --branch {branch-name} https://github.com/microsoft/autogen.git
+  git clone --branch {branch-name} https://github.com/autogen-ai/autogen.git
 
   # cd to your new directory
   cd autogen
@@ -33,16 +33,16 @@ For developers contributing to the AutoGen project, we offer a specialized Docke
 
 ## Using the Developer Docker Image
 
-Once you have built the `autogen_dev_img`, you can run it using the standard Docker commands. This will place you inside the containerized development environment where you can run tests, develop code, and ensure everything is functioning as expected before submitting your contributions.
+Once you have built the `autogen_ai_dev_img`, you can run it using the standard Docker commands. This will place you inside the containerized development environment where you can run tests, develop code, and ensure everything is functioning as expected before submitting your contributions.
 
 ```bash
-docker run -it -p 8081:3000 -v `pwd`/autogen-newcode:newstuff/ autogen_dev_img bash
+docker run -it -p 8081:3000 -v `pwd`/autogen-newcode:newstuff/ autogen_ai_dev_img bash
 ```
 
 - Note that the `pwd` is shorthand for present working directory. Thus, any path after the pwd is relative to that. If you want a more verbose method you could remove the "`pwd`/autogen-newcode" and replace it with the full path to your directory
 
 ```bash
-docker run -it -p 8081:3000 -v /home/AutoGenDeveloper/autogen-newcode:newstuff/ autogen_dev_img bash
+docker run -it -p 8081:3000 -v /home/AutoGenDeveloper/autogen-newcode:newstuff/ autogen_ai_dev_img bash
 ```
 
 ## Develop in Remote Container

--- a/website/docs/contributor-guide/documentation.md
+++ b/website/docs/contributor-guide/documentation.md
@@ -39,13 +39,13 @@ Most changes are reflected live without having to restart the server.
 To build and test documentation within a docker container. Use the Dockerfile in the `dev` folder as described above to build your image:
 
 ```bash
-docker build -f .devcontainer/dev/Dockerfile -t autogen_dev_img https://github.com/microsoft/autogen.git#main
+docker build -f .devcontainer/dev/Dockerfile -t autogen_ai_dev_img https://github.com/autogen-ai/autogen.git#main
 ```
 
 Then start the container like so, this will log you in and ensure that Docker port 3000 is mapped to port 8081 on your local machine
 
 ```bash
-docker run -it -p 8081:3000 -v `pwd`/autogen-newcode:newstuff/ autogen_dev_img bash
+docker run -it -p 8081:3000 -v `pwd`/autogen-newcode:newstuff/ autogen_ai_dev_img bash
 ```
 
 Once at the CLI in Docker run the following commands:

--- a/website/docs/installation/Docker.md
+++ b/website/docs/installation/Docker.md
@@ -1,11 +1,11 @@
 # Docker
 
-Docker, an indispensable tool in modern software development, offers a compelling solution for AutoGen's setup. Docker allows you to create consistent environments that are portable and isolated from the host OS. With Docker, everything AutoGen needs to run, from the operating system to specific libraries, is encapsulated in a container, ensuring uniform functionality across different systems. The Dockerfiles necessary for AutoGen are conveniently located in the project's GitHub repository at [https://github.com/microsoft/autogen/tree/main/.devcontainer](https://github.com/microsoft/autogen/tree/main/.devcontainer).
+Docker, an indispensable tool in modern software development, offers a compelling solution for AutoGen's setup. Docker allows you to create consistent environments that are portable and isolated from the host OS. With Docker, everything AutoGen needs to run, from the operating system to specific libraries, is encapsulated in a container, ensuring uniform functionality across different systems. The Dockerfiles necessary for AutoGen are conveniently located in the project's GitHub repository at [https://github.com/autogen-ai/autogen/tree/main/.devcontainer](https://github.com/autogen-ai/autogen/tree/main/.devcontainer).
 
 **Pre-configured DockerFiles**: The AutoGen Project offers pre-configured Dockerfiles for your use. These Dockerfiles will run as is, however they can be modified to suit your development needs. Please see the README.md file in autogen/.devcontainer
 
-- **autogen_base_img**: For a basic setup, you can use the `autogen_base_img` to run simple scripts or applications. This is ideal for general users or those new to AutoGen.
-- **autogen_full_img**: Advanced users or those requiring more features can use `autogen_full_img`. Be aware that this version loads ALL THE THINGS and thus is very large. Take this into consideration if you build your application off of it.
+- **autogen_ai_base_img**: For a basic setup, you can use the `autogen_ai_base_img` to run simple scripts or applications. This is ideal for general users or those new to AutoGen.
+- **autogen_ai_full_img**: Advanced users or those requiring more features can use `autogen_ai_full_img`. Be aware that this version loads ALL THE THINGS and thus is very large. Take this into consideration if you build your application off of it.
 
 ## Step 1: Install Docker
 
@@ -20,13 +20,13 @@ AutoGen now provides updated Dockerfiles tailored for different needs. Building 
 - **Autogen Basic**: Ideal for general use, this setup includes common Python libraries and essential dependencies. Perfect for those just starting with AutoGen.
 
   ```bash
-  docker build -f .devcontainer/Dockerfile -t autogen_base_img https://github.com/microsoft/autogen.git#main
+  docker build -f .devcontainer/Dockerfile -t autogen_ai_base_img https://github.com/autogen-ai/autogen.git#main
   ```
 
-- **Autogen Advanced**: Advanced users or those requiring all the things that AutoGen has to offer `autogen_full_img`
+- **Autogen Advanced**: Advanced users or those requiring all the things that AutoGen has to offer `autogen_ai_full_img`
 
   ```bash
-  docker build -f .devcontainer/full/Dockerfile -t autogen_full_img https://github.com/microsoft/autogen.git#main
+  docker build -f .devcontainer/full/Dockerfile -t autogen_ai_full_img https://github.com/autogen-ai/autogen.git#main
   ```
 
 ## Step 3: Run AutoGen Applications from Docker Image
@@ -36,22 +36,22 @@ Here's how you can run an application built with AutoGen, using the Docker image
 1. **Mount Your Directory**: Use the Docker `-v` flag to mount your local application directory to the Docker container. This allows you to develop on your local machine while running the code in a consistent Docker environment. For example:
 
    ```bash
-   docker run -it -v $(pwd)/myapp:/home/autogen/autogen/myapp autogen_base_img:latest python /home/autogen/autogen/myapp/main.py
+   docker run -it -v $(pwd)/myapp:/home/autogen-ai/autogen/myapp autogen_ai_base_img:latest python /home/autogen-ai/autogen/myapp/main.py
    ```
 
-   Here, `$(pwd)/myapp` is your local directory, and `/home/autogen/autogen/myapp` is the path in the Docker container where your code will be located.
+   Here, `$(pwd)/myapp` is your local directory, and `/home/autogen-ai/autogen/myapp` is the path in the Docker container where your code will be located.
 
-2. **Mount your code:** Now suppose you have your application built with AutoGen in a main script named `twoagent.py` ([example](https://github.com/microsoft/autogen/blob/main/test/twoagent.py)) in a folder named `myapp`. With the command line below, you can mount your folder and run the application in Docker.
+2. **Mount your code:** Now suppose you have your application built with AutoGen in a main script named `twoagent.py` ([example](https://github.com/autogen-ai/autogen/blob/main/test/twoagent.py)) in a folder named `myapp`. With the command line below, you can mount your folder and run the application in Docker.
 
    ```python
    # Mount the local folder `myapp` into docker image and run the script named "twoagent.py" in the docker.
-   docker run -it -v `pwd`/myapp:/myapp autogen_img:latest python /myapp/main_twoagent.py
+   docker run -it -v `pwd`/myapp:/myapp autogen_ai_base_img:latest python /myapp/main_twoagent.py
    ```
 
 3. **Port Mapping**: If your application requires a specific port, use the `-p` flag to map the container's port to your host. For instance, if your app runs on port 3000 inside Docker and you want it accessible on port 8080 on your host machine:
 
    ```bash
-   docker run -it -p 8080:3000 -v $(pwd)/myapp:/myapp autogen_base_img:latest python /myapp
+   docker run -it -p 8080:3000 -v $(pwd)/myapp:/myapp autogen_ai_base_img:latest python /myapp
    ```
 
    In this command, `-p 8080:3000` maps port 3000 from the container to port 8080 on your local machine.
@@ -65,23 +65,23 @@ docker run -it -p {WorkstationPortNum}:{DockerPortNum} -v {WorkStation_Dir}:{Doc
 - _Simple Script_: Run a Python script located in your local `myapp` directory.
 
   ```bash
-  docker run -it -v `pwd`/myapp:/myapp autogen_base_img:latest python /myapp/my_script.py
+  docker run -it -v `pwd`/myapp:/myapp autogen_ai_base_img:latest python /myapp/my_script.py
   ```
 
 - _Web Application_: If your application includes a web server running on port 5000.
 
   ```bash
-  docker run -it -p 8080:5000 -v $(pwd)/myapp:/myapp autogen_base_img:latest
+  docker run -it -p 8080:5000 -v $(pwd)/myapp:/myapp autogen_ai_base_img:latest
   ```
 
 - _Data Processing_: For tasks that involve processing data stored in a local directory.
 
   ```bash
-  docker run -it -v $(pwd)/data:/data autogen_base_img:latest python /myapp/process_data.py
+  docker run -it -v $(pwd)/data:/data autogen_ai_base_img:latest python /myapp/process_data.py
   ```
 
 ## Additional Resources
 
-- Details on all the Dockerfile options can be found in the [Dockerfile](https://github.com/microsoft/autogen/blob/main/.devcontainer/README.md) README.
+- Details on all the Dockerfile options can be found in the [Dockerfile](https://github.com/autogen-ai/autogen/blob/main/.devcontainer/README.md) README.
 - For more information on Docker usage and best practices, refer to the [official Docker documentation](https://docs.docker.com).
 - Details on how to use the Dockerfile dev version can be found on the [Contributor Guide](/docs/contributor-guide/docker).


### PR DESCRIPTION
## Why are these changes needed?

Instructions/files for contributing developers, such as the Dockerfiles, need to be aligned with the current repository's URL.

Adjusting docker image names and paths within the container to align with the URL.

## Related issue number

None

## Checks

- [X] I've made sure all auto checks have passed.
