### PR TITLE
Group Chat - Updates to resume

### DIFF
--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1270,11 +1270,15 @@ class GroupChatManager(ConversableAgent):
             if not message_speaker_agent and message["name"] == self.name:
                 message_speaker_agent = self
 
-            # Add previous messages to each agent (except their own messages and the last message, as we'll kick off the conversation with it)
+            # Add previous messages to each agent (except the last message, as we'll kick off the conversation with it)
             if i != len(messages) - 1:
                 for agent in self._groupchat.agents:
-                    if agent.name != message["name"]:
-                        self.send(message, self._groupchat.agent_by_name(agent.name), request_reply=False, silent=True)
+                    if agent.name == message["name"]:
+                        # An agent`s message is sent to the Group Chat Manager
+                        agent.send(message, self, request_reply=False, silent=True)
+                    else:
+                        # Otherwise, messages are sent from the Group Chat Manager to the agent
+                        self.send(message, agent, request_reply=False, silent=True)
 
                 # Add previous message to the new groupchat, if it's an admin message the name may not match so add the message directly
                 if message_speaker_agent:

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1212,7 +1212,7 @@ class GroupChatManager(ConversableAgent):
     def resume(
         self,
         messages: Union[List[Dict], str],
-        remove_termination_string: Union[str, Callable[[str], str]] = None,
+        remove_termination_string: Optional[Union[str, Callable[[str], str]]] = None,
         silent: Optional[bool] = False,
     ) -> Tuple[ConversableAgent, Dict]:
         """Resumes a group chat using the previous messages as a starting point. Requires the agents, group chat, and group chat manager to be established
@@ -1316,7 +1316,7 @@ class GroupChatManager(ConversableAgent):
     async def a_resume(
         self,
         messages: Union[List[Dict], str],
-        remove_termination_string: Union[str, Callable[[str], str]],
+        remove_termination_string: Optional[Union[str, Callable[[str], str]]] = None,
         silent: Optional[bool] = False,
     ) -> Tuple[ConversableAgent, Dict]:
         """Resumes a group chat using the previous messages as a starting point, asynchronously. Requires the agents, group chat, and group chat manager to be established

--- a/autogen/agentchat/groupchat.py
+++ b/autogen/agentchat/groupchat.py
@@ -1378,13 +1378,15 @@ class GroupChatManager(ConversableAgent):
             if not message_speaker_agent and message["name"] == self.name:
                 message_speaker_agent = self
 
-            # Add previous messages to each agent (except their own messages and the last message, as we'll kick off the conversation with it)
+            # Add previous messages to each agent (except the last message, as we'll kick off the conversation with it)
             if i != len(messages) - 1:
                 for agent in self._groupchat.agents:
-                    if agent.name != message["name"]:
-                        await self.a_send(
-                            message, self._groupchat.agent_by_name(agent.name), request_reply=False, silent=True
-                        )
+                    if agent.name == message["name"]:
+                        # An agent`s message is sent to the Group Chat Manager
+                        agent.a_send(message, self, request_reply=False, silent=True)
+                    else:
+                        # Otherwise, messages are sent from the Group Chat Manager to the agent
+                        self.a_send(message, agent, request_reply=False, silent=True)
 
                 # Add previous message to the new groupchat, if it's an admin message the name may not match so add the message directly
                 if message_speaker_agent:

--- a/test/agentchat/test_groupchat.py
+++ b/test/agentchat/test_groupchat.py
@@ -2067,6 +2067,51 @@ def test_manager_resume_messages():
         return_agent, return_message = manager.resume(messages="Let's get this conversation started.")
 
 
+def test_manager_resume_message_assignment():
+    """Tests that the messages passed in are assigned to agents correctly"""
+
+    # Setup
+    agent_a = AssistantAgent(name="Agent_A", llm_config=None)
+    agent_b = AssistantAgent(name="Agent_B", llm_config=None)
+    agent_c = AssistantAgent(name="Agent_C", llm_config=None)
+    groupchat = GroupChat(messages=[], agents=[agent_a, agent_b, agent_c])
+    manager = GroupChatManager(groupchat)
+
+    # Messages representing the previous state (based on agent_a where role will be assistant)
+    prev_messages = [
+        {
+            "content": "Let's build a new app!",
+            "name": "Agent_A",
+            "role": "assistant",
+        },
+        {
+            "content": "This is Agent C's message",
+            "name": "Agent_C",
+            "role": "user",
+        },
+        {
+            "content": "This is Agent A's message",
+            "name": "Agent_A",
+            "role": "assistant",
+        },
+        {
+            "content": "This is Agent B's message",
+            "name": "Agent_B",
+            "role": "user",
+        },
+        {
+            "content": "This is Agent C's message",
+            "name": "Agent_C",
+            "role": "user",
+        },
+    ]
+
+    return_agent, return_message = manager.resume(messages=prev_messages)
+
+    # Compare agent_a's message state to previous messages (excludes last message)
+    assert list(agent_a.chat_messages.values())[0] == prev_messages[:-1]
+
+
 if __name__ == "__main__":
     # test_func_call_groupchat()
     # test_broadcast()
@@ -2092,7 +2137,8 @@ if __name__ == "__main__":
     # test_select_speaker_auto_messages()
     # test_manager_messages_to_string()
     # test_manager_messages_from_string()
-    test_manager_resume_functions()
+    # test_manager_resume_functions()
     # test_manager_resume_returns()
     # test_manager_resume_messages()
+    test_manager_resume_message_assignment()
     pass


### PR DESCRIPTION
This PR addresses the need to populate a group chat's agents completely when resuming.

Additional fix to make `resume_termination_string` optional and default to `None`.

## Why are these changes needed?

Issues have been identified when attempting to resume when messages were not fully populated.

Similarly, `resume_termination_string` not defaulting to `None` was overridden and needs to be restored. Added Optional as well.

## Related issue number

## Checks

- [ ] I've included any doc changes needed for https://autogen-ai.github.io/autogen/. See https://autogen-ai.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
