### PR TITLE
Add a `run` api?

### DIFF
--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -2132,6 +2132,20 @@ class ConversableAgent(LLMAgent):
                     return reply
         return self._default_auto_reply
 
+    def run(
+        self,
+        message: str,
+        sender: Optional["Agent"] = None,
+    ):
+        if sender is not None:
+            all_message = self._oai_messages[sender]
+            all_message.append({"content": message, "role": "user"})
+            self._oai_messages[sender] = all_message
+        else:
+            all_message = [{"content": message, "role": "user"}]
+        reply = self.generate_reply(messages=all_message)
+        return reply
+
     def _match_trigger(self, trigger: Union[None, str, type, Agent, Callable, List], sender: Optional[Agent]) -> bool:
         """Check if the sender matches the trigger.
 

--- a/website/docs/tutorial/introduction.ipynb
+++ b/website/docs/tutorial/introduction.ipynb
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,19 +108,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can ask this agent to generate a response to a question using the `generate_reply` method:"
+    "You can ask this agent to generate a response to a question using the `run` (recommended) method or `generate_reply` method:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sure, here's a light-hearted joke for you:\n",
+      "Sure, here's one for you:\n",
+      "\n",
+      "Why don't scientists trust atoms?\n",
+      "\n",
+      "Because they make up everything!\n"
+     ]
+    }
+   ],
+   "source": [
+    "reply = agent.run(message=\"Tell me a joke.\")\n",
+    "print(reply)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sure, here's one for you:\n",
       "\n",
       "Why don't scientists trust atoms?\n",
       "\n",
@@ -257,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://autogen-ai.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

In many scenarios, we may just want to involve one single agent to finish a straightforward task. Currently, we need to do that through `generate_reply`, which is not easy to use. To improve usability, shall we add this `run` API? This addition won't break the existing usage of `generate_reply`. 

The change in this PR is an initial proposal. If we agree we should add this `run` API, there are more changes to be made. 

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://autogen-ai.github.io/autogen/. See https://autogen-ai.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
