### PR TITLE
OpenAI o1 model support

### DIFF
--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -31,6 +31,12 @@ NON_CACHE_KEY = [
 DEFAULT_AZURE_API_VERSION = "2024-02-01"
 OAI_PRICE1K = {
     # https://openai.com/api/pricing/
+    # o1
+    "o1-preview": (0.015, 0.06),
+    "o1-preview-2024-09-12": (0.015, 0.06),
+    # o1-mini
+    "o1-mini": (0.003, 0.012),
+    "o1-mini-2024-09-12": (0.003, 0.012),
     # gpt-4o
     "gpt-4o": (0.005, 0.015),
     "gpt-4o-2024-05-13": (0.005, 0.015),

--- a/autogen/token_count_utils.py
+++ b/autogen/token_count_utils.py
@@ -114,14 +114,14 @@ def _num_token_from_messages(messages: Union[List, Dict], model="gpt-3.5-turbo-0
         tokens_per_message = 4  # every message follows <|start|>{role/name}\n{content}<|end|>\n
         tokens_per_name = 1  # OpenAI guidance is 1 extra token if 'name' field is used
     elif "gemini" in model:
-        logger.info("Gemini is not supported in tiktoken. Returning num tokens assuming gpt-4.")
-        return _num_token_from_messages(messages, model="gpt-4")
+        logger.info("Gemini is not supported in tiktoken. Returning num tokens assuming gpt-4-0613 (2023).")
+        return _num_token_from_messages(messages, model="gpt-4-0613")
     elif "claude" in model:
-        logger.info("Claude is not supported in tiktoken. Returning num tokens assuming gpt-4.")
-        return _num_token_from_messages(messages, model="gpt-4")
+        logger.info("Claude is not supported in tiktoken. Returning num tokens assuming gpt-4-0613 (2023).")
+        return _num_token_from_messages(messages, model="gpt-4-0613")
     elif "mistral-" in model or "mixtral-" in model:
-        logger.info("Mistral.AI models are not supported in tiktoken. Returning num tokens assuming gpt-4.")
-        return _num_token_from_messages(messages, model="gpt-4")
+        logger.info("Mistral.AI models are not supported in tiktoken. Returning num tokens assuming gpt-4-0613 (2023).")
+        return _num_token_from_messages(messages, model="gpt-4-0613")
     else:
         raise NotImplementedError(
             f"""_num_token_from_messages() is not implemented for model {model}. See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens."""

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ __version__ = version["__version__"]
 current_os = platform.system()
 
 install_requires = [
-    "openai>=1.3",
+    "openai>=1.51",
     "diskcache",
     "termcolor",
     "flaml",

--- a/test/agentchat/contrib/test_gpt_assistant.py
+++ b/test/agentchat/contrib/test_gpt_assistant.py
@@ -34,6 +34,8 @@ if not skip_openai:
         filter_dict={
             "api_type": ["openai"],
             "model": [
+                "o1-preview",
+                "o1-mini",
                 "gpt-4o-mini",
                 "gpt-4o",
                 "gpt-4-turbo",

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -37,6 +37,8 @@ gpt4_config_list = [
     {"model": "gpt-4-32k"},
     {"model": "gpt-4o"},
     {"model": "gpt-4o-mini"},
+    {"model": "o1-preview"},
+    {"model": "o1-mini"},
 ]
 
 

--- a/test/agentchat/test_function_call.py
+++ b/test/agentchat/test_function_call.py
@@ -238,7 +238,7 @@ def test_update_function():
     config_list_gpt4 = autogen.config_list_from_json(
         OAI_CONFIG_LIST,
         filter_dict={
-            "tags": ["gpt-4", "gpt-4-32k", "gpt-4o", "gpt-4o-mini", "o1-preview", "o1-mini"],
+            "tags": ["gpt-4", "gpt-4-32k", "gpt-4o", "gpt-4o-mini"],
         },
         file_location=KEY_LOC,
     )

--- a/test/agentchat/test_function_call.py
+++ b/test/agentchat/test_function_call.py
@@ -238,7 +238,7 @@ def test_update_function():
     config_list_gpt4 = autogen.config_list_from_json(
         OAI_CONFIG_LIST,
         filter_dict={
-            "tags": ["gpt-4", "gpt-4-32k", "gpt-4o", "gpt-4o-mini"],
+            "tags": ["gpt-4", "gpt-4-32k", "gpt-4o", "gpt-4o-mini", "o1-preview", "o1-mini"],
         },
         file_location=KEY_LOC,
     )

--- a/test/test_token_count.py
+++ b/test/test_token_count.py
@@ -72,9 +72,9 @@ def test_count_token():
             "content": "hello asdfjj qeweee",
         },
     ]
-    assert count_token(messages) == 34
-    assert percentile_used(messages) == 34 / 4096
-    assert token_left(messages) == 4096 - 34
+    assert count_token(messages) == 35
+    assert percentile_used(messages) == 35 / 4096
+    assert token_left(messages) == 4096 - 35
 
     text = "I'm sorry, but I'm not able to"
     assert count_token(text) == 10


### PR DESCRIPTION
## Why are these changes needed?

OpenAI has just released o1-mini and o1-preview, these changes add support for the model.

I don't have level 5 API access to test against the API, if anyone can test with the models that would be great.

Notes:
- OpenAI is depreciating `max_tokens` and `max_completion_tokens` should be used. Code maps `max_tokens` to `max_completion_tokens`.
- [Beta limitations](https://platform.openai.com/docs/guides/reasoning/beta-limitations)

Tests still TODO.

## Related issue number

## Checks

- [ ] I've included any doc changes needed for https://autogen-ai.github.io/autogen/. See https://autogen-ai.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
