### PR TITLE
OpenAI API key format validation

### DIFF
--- a/autogen/oai/openai_utils.py
+++ b/autogen/oai/openai_utils.py
@@ -106,7 +106,9 @@ def get_key(config: Dict[str, Any]) -> str:
 
 
 def is_valid_api_key(api_key: str) -> bool:
-    """Determine if input is valid OpenAI API key.
+    """Determine if input is valid OpenAI API key. As of 2024-09-24 there's no official definition of the key structure
+    so we will allow anything starting with "sk-" and having at least 48 alphanumeric (plus underscore and dash) characters.
+    Keys are known to start with "sk-", "sk-proj", "sk-None", and "sk-svcaat"
 
     Args:
         api_key (str): An input string to be validated.
@@ -114,7 +116,7 @@ def is_valid_api_key(api_key: str) -> bool:
     Returns:
         bool: A boolean that indicates if input is valid OpenAI API key.
     """
-    api_key_re = re.compile(r"^sk-([A-Za-z0-9]+(-+[A-Za-z0-9]+)*-)?[A-Za-z0-9]{32,}$")
+    api_key_re = re.compile(r"^sk-[A-Za-z0-9_-]{48,}$")
     return bool(re.fullmatch(api_key_re, api_key))
 
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ jupyter_executor = [
 
 retrieve_chat = [
     "protobuf==4.25.3",
-    "chromadb",
+    "chromadb==0.5.3",
     "sentence_transformers",
     "pypdf",
     "ipython",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,7 +10,7 @@ skip_openai = False
 skip_redis = False
 skip_docker = False
 reason = "requested to skip"
-MOCK_OPEN_AI_API_KEY = "sk-mockopenaiAPIkeyinexpectedformatfortestingonly"
+MOCK_OPEN_AI_API_KEY = "sk-mockopenaiAPIkeysinexpectedformatsfortestingonly"
 
 
 # Registers command-line options like '--skip-openai' and '--skip-redis' via pytest hook.

--- a/test/oai/test_utils.py
+++ b/test/oai/test_utils.py
@@ -427,15 +427,22 @@ def test_is_valid_api_key():
     assert not is_valid_api_key("sk-asajsdjsd2")
     assert not is_valid_api_key("FooBar")
     assert not is_valid_api_key("sk-asajsdjsd22372%23kjdfdfdf2329ffUUDSDS")
-    assert is_valid_api_key("sk-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS")
+    assert is_valid_api_key(
+        "sk-1b7n_YEvn7mmiUqkipH-JXk7DvqYoacDoe6Ae8v212T3BlbkFJWFRrGd3ZHN9GpZWX9Zx13gLolZ3NqcMFvb7ov5tzeA"
+    )  # correct format, not real
+    assert is_valid_api_key(
+        "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"
+    )  # correct format, not real
     assert is_valid_api_key("sk-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS1212121221212sssXX")
     assert is_valid_api_key("sk-proj-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
+    assert is_valid_api_key("sk-None-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
+    assert is_valid_api_key("sk-svcaat-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
     assert is_valid_api_key("sk-0-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
     assert is_valid_api_key("sk-aut0gen-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
     assert is_valid_api_key("sk-aut0-gen-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
     assert is_valid_api_key("sk-aut0--gen-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
-    assert not is_valid_api_key("sk-aut0-gen--asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
-    assert not is_valid_api_key("sk--aut0-gen-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
+    assert is_valid_api_key("sk-aut0-gen--asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
+    assert is_valid_api_key("sk--aut0-gen-asajsdjsd22372X23kjdfdfdf2329ffUUDSDS12121212212")
     assert is_valid_api_key(MOCK_OPEN_AI_API_KEY)
 
 


### PR DESCRIPTION
## Why are these changes needed?

OpenAI's API key has changed in format recently and the validation function in OpenAI doesn't accurately validate the format.

OpenAI has not published the format of the key, so information gathered so far is that it can start with:
`sk-`
`sk-proj-`
`sk-None-`
`sk-svcaat-`

This is followed by segments of alphanumeric characters (including underscores) separated by dashes.

As the exact format is not defined, the regular expression in the validation function will be expanded to support keys:
- starting with `sk-`
- followed by at least 48 alphanumeric characters (including underscores and dashes)

The tests have been updated.

## Related issue number

Closes #26 

## Checks

- [ ] I've included any doc changes needed for https://autogen-ai.github.io/autogen/. See https://autogen-ai.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
