### PR TITLE
Updated parameter handling for Ollama

### DIFF
--- a/autogen/oai/ollama.py
+++ b/autogen/oai/ollama.py
@@ -128,7 +128,7 @@ class OllamaClient:
 
         if "num_predict" in params:
             # Maximum number of tokens to predict, note: -1 is infinite, -2 is fill context, 128 is default
-            ollama_params["num_predict"] = validate_parameter(params, "num_predict", int, False, 128, None, None)
+            options_dict["num_predict"] = validate_parameter(params, "num_predict", int, False, 128, None, None)
 
         if "repeat_penalty" in params:
             options_dict["repeat_penalty"] = validate_parameter(
@@ -139,15 +139,15 @@ class OllamaClient:
             options_dict["seed"] = validate_parameter(params, "seed", int, False, 42, None, None)
 
         if "temperature" in params:
-            ollama_params["temperature"] = validate_parameter(
+            options_dict["temperature"] = validate_parameter(
                 params, "temperature", (int, float), False, 0.8, None, None
             )
 
         if "top_k" in params:
-            ollama_params["top_k"] = validate_parameter(params, "top_k", int, False, 40, None, None)
+            options_dict["top_k"] = validate_parameter(params, "top_k", int, False, 40, None, None)
 
         if "top_p" in params:
-            ollama_params["top_p"] = validate_parameter(params, "top_p", (int, float), False, 0.9, None, None)
+            options_dict["top_p"] = validate_parameter(params, "top_p", (int, float), False, 0.9, None, None)
 
         if self._native_tool_calls and self._tools_in_conversation and not self._should_hide_tools:
             ollama_params["tools"] = params["tools"]

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ extra_require = {
     "mistral": ["mistralai>=1.0.1"],
     "groq": ["groq>=0.9.0"],
     "cohere": ["cohere>=5.5.8"],
-    "ollama": ["ollama>=0.3.2", "fix_busted_json>=0.0.18"],
+    "ollama": ["ollama>=0.3.3", "fix_busted_json>=0.0.18"],
     "bedrock": ["boto3>=1.34.149"],
 }
 

--- a/test/oai/test_ollama.py
+++ b/test/oai/test_ollama.py
@@ -65,13 +65,13 @@ def test_parsing_params(ollama_client):
     }
     expected_params = {
         "model": "llama3.1:8b",
-        "temperature": 0.8,
-        "num_predict": 128,
-        "top_k": 40,
-        "top_p": 0.9,
         "options": {
             "repeat_penalty": 1.1,
             "seed": 42,
+            "temperature": 0.8,
+            "num_predict": 128,
+            "top_k": 40,
+            "top_p": 0.9,
         },
         "stream": False,
     }


### PR DESCRIPTION
## Why are these changes needed?

Ollama's API expects a number of LLM parameters to now be in the options attribute. Have updated the library to move a number of parameters into the options dictionary attribute.

Parameters that should be in the options dictionary noted [here](https://github.com/ollama/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values).

## Related issue number

None

## Checks

- [ ] I've included any doc changes needed for https://autogen-ai.github.io/autogen/. See https://autogen-ai.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
