### PR TITLE
Fix: added agent name to client.create calls to prevent runtime loggi…

### DIFF
--- a/autogen/agentchat/contrib/multimodal_conversable_agent.py
+++ b/autogen/agentchat/contrib/multimodal_conversable_agent.py
@@ -117,7 +117,9 @@ class MultimodalConversableAgent(ConversableAgent):
         messages_with_b64_img = message_formatter_pil_to_b64(self._oai_system_message + messages)
 
         # TODO: #1143 handle token limit exceeded error
-        response = client.create(context=messages[-1].pop("context", None), messages=messages_with_b64_img, agent=self.name)
+        response = client.create(
+            context=messages[-1].pop("context", None), messages=messages_with_b64_img, agent=self.name
+        )
 
         # TODO: line 301, line 271 is converting messages to dict. Can be removed after ChatCompletionMessage_to_dict is merged.
         extracted_response = client.extract_text_or_completion_object(response)[0]

--- a/autogen/agentchat/contrib/multimodal_conversable_agent.py
+++ b/autogen/agentchat/contrib/multimodal_conversable_agent.py
@@ -117,7 +117,7 @@ class MultimodalConversableAgent(ConversableAgent):
         messages_with_b64_img = message_formatter_pil_to_b64(self._oai_system_message + messages)
 
         # TODO: #1143 handle token limit exceeded error
-        response = client.create(context=messages[-1].pop("context", None), messages=messages_with_b64_img)
+        response = client.create(context=messages[-1].pop("context", None), messages=messages_with_b64_img, agent=self.name)
 
         # TODO: line 301, line 271 is converting messages to dict. Can be removed after ChatCompletionMessage_to_dict is merged.
         extracted_response = client.extract_text_or_completion_object(response)[0]

--- a/autogen/agentchat/contrib/society_of_mind_agent.py
+++ b/autogen/agentchat/contrib/society_of_mind_agent.py
@@ -131,7 +131,7 @@ class SocietyOfMindAgent(ConversableAgent):
             }
         )
 
-        response = self.client.create(context=None, messages=_messages, cache=self.client_cache)
+        response = self.client.create(context=None, messages=_messages, cache=self.client_cache, agent=self.name)
         extracted_response = self.client.extract_text_or_completion_object(response)[0]
         if not isinstance(extracted_response, str):
             return str(extracted_response.model_dump(mode="dict"))


### PR DESCRIPTION
Fix: added agent name to client.create calls to prevent runtime logging error (#3507)

- Modified the `client.create` call in `multimodal_conversable_agent.py` by adding `agent=self.name` as a parameter.
- Updated the `client.create` call in `society_of_mind_agent.py` with `agent=self.name`.

These changes ensure that the agent's name is passed correctly, preventing the `NoneType` error during runtime logging in `MultimodalConversableAgent`.
