### PR TITLE
Replace logging formatter from FLAML to avoid warning

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -12,12 +12,12 @@ import sys
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, Union
 
-from flaml.automl.logger import logger_formatter
 from pydantic import BaseModel
 
 from autogen.cache import Cache
 from autogen.io.base import IOStream
 from autogen.logger.logger_utils import get_current_ts
+from autogen.oai.client_utils import logging_formatter
 from autogen.oai.openai_utils import OAI_PRICE1K, get_key, is_valid_api_key
 from autogen.runtime_logging import log_chat_completion, log_new_client, log_new_wrapper, logging_enabled
 from autogen.token_count_utils import count_token
@@ -168,7 +168,7 @@ logger = logging.getLogger(__name__)
 if not logger.handlers:
     # Add the console handler.
     _ch = logging.StreamHandler(stream=sys.stdout)
-    _ch.setFormatter(logger_formatter)
+    _ch.setFormatter(logging_formatter)
     logger.addHandler(_ch)
 
 LEGACY_DEFAULT_CACHE_SEED = 41

--- a/autogen/oai/client_utils.py
+++ b/autogen/oai/client_utils.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: MIT
 """Utilities for client classes"""
 
+import logging
 import warnings
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -158,3 +159,9 @@ def should_hide_tools(messages: List[Dict[str, Any]], tools: List[Dict[str, Any]
         raise TypeError(
             f"hide_tools_param is not a valid value ['if_all_run','if_any_run','never'], got '{hide_tools_param}'"
         )
+
+
+# Logging format (originally from FLAML)
+logging_formatter = logging.Formatter(
+    "[%(name)s: %(asctime)s] {%(lineno)d} %(levelname)s - %(message)s", "%m-%d %H:%M:%S"
+)

--- a/autogen/oai/cohere.py
+++ b/autogen/oai/cohere.py
@@ -37,18 +37,17 @@ from typing import Any, Dict, List
 
 from cohere import Client as Cohere
 from cohere.types import ToolParameterDefinitionsValue, ToolResult
-from flaml.automl.logger import logger_formatter
 from openai.types.chat import ChatCompletion, ChatCompletionMessageToolCall
 from openai.types.chat.chat_completion import ChatCompletionMessage, Choice
 from openai.types.completion_usage import CompletionUsage
 
-from autogen.oai.client_utils import validate_parameter
+from autogen.oai.client_utils import logging_formatter, validate_parameter
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:
     # Add the console handler.
     _ch = logging.StreamHandler(stream=sys.stdout)
-    _ch.setFormatter(logger_formatter)
+    _ch.setFormatter(logging_formatter)
     logger.addHandler(_ch)
 
 

--- a/autogen/oai/completion.py
+++ b/autogen/oai/completion.py
@@ -14,9 +14,9 @@ from typing import Callable, Dict, List, Optional, Union
 
 import numpy as np
 from flaml import BlendSearch, tune
-from flaml.automl.logger import logger_formatter
 from flaml.tune.space import is_constant
 
+from .client_utils import logging_formatter
 from .openai_utils import get_key
 
 try:
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 if not logger.handlers:
     # Add the console handler.
     _ch = logging.StreamHandler(stream=sys.stdout)
-    _ch.setFormatter(logger_formatter)
+    _ch.setFormatter(logging_formatter)
     logger.addHandler(_ch)
 
 


### PR DESCRIPTION
## Why are these changes needed?

Updates to the FLAML package have resulted in a warning message showing when running AutoGen, such as with ConversableAgent's initiate_chat:
`flaml.automl is not available. Please install flaml[automl] to enable AutoML functionalities.`

[The line of FLAML code is here](https://github.com/microsoft/FLAML/blob/5c0f18b7bc705befb7e5bd400d204e6be04640d9/flaml/__init__.py#L18).

It appears related to logging and we can replace the need for the FLAML logging by copying the logging Formatter:
```
logging_formatter = logging.Formatter(
    "[%(name)s: %(asctime)s] {%(lineno)d} %(levelname)s - %(message)s", "%m-%d %H:%M:%S"
)
```

I've put this in client_utils and replaced references:
`from flaml.automl.logger import logger_formatter`

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://autogen-ai.github.io/autogen/. See https://autogen-ai.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
