### PR TITLE
Cerebras exception correction and Gemini installation advice

### DIFF
--- a/autogen/oai/client.py
+++ b/autogen/oai/client.py
@@ -59,6 +59,7 @@ try:
 
     cerebras_import_exception: Optional[ImportError] = None
 except ImportError as e:
+    cerebras_AuthenticationError = cerebras_InternalServerError = cerebras_RateLimitError = Exception
     cerebras_import_exception = e
 
 try:
@@ -577,7 +578,7 @@ class OpenAIWrapper:
                 self._clients.append(client)
             elif api_type is not None and api_type.startswith("google"):
                 if gemini_import_exception:
-                    raise ImportError("Please install `google-generativeai` to use Google OpenAI API.")
+                    raise ImportError("Please install `google-generativeai` and 'vertexai' to use Google's API.")
                 client = GeminiClient(**openai_config)
                 self._clients.append(client)
             elif api_type is not None and api_type.startswith("anthropic"):


### PR DESCRIPTION
## Why are these changes needed?

1. Currently, if there's an exception raised in the client classes it will fail as the Cerebras exceptions aren't defaulted to an `Exception` object if Cerebras is not installed. This corrects that.
2. To run the Gemini client class both `google-generativeai` and `vertexai` packages need to be installed. Currently the ImportError message omits the `vertexai` requirement. This corrects that.


## Checks

- [ ] I've included any doc changes needed for https://autogen-ai.github.io/autogen/. See https://autogen-ai.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
