### PR TITLE
Correct TextMessageCompressor's cache parameter initialising on import

### DIFF
--- a/autogen/agentchat/contrib/capabilities/transforms.py
+++ b/autogen/agentchat/contrib/capabilities/transforms.py
@@ -325,7 +325,7 @@ class TextMessageCompressor:
         text_compressor: Optional[TextCompressor] = None,
         min_tokens: Optional[int] = None,
         compression_params: Dict = dict(),
-        cache: Optional[AbstractCache] = Cache.disk(),
+        cache: Optional[AbstractCache] = None,
         filter_dict: Optional[Dict] = None,
         exclude_filter: bool = True,
     ):
@@ -355,7 +355,11 @@ class TextMessageCompressor:
         self._compression_args = compression_params
         self._filter_dict = filter_dict
         self._exclude_filter = exclude_filter
-        self._cache = cache
+
+        if cache is None:
+            self._cache = Cache.disk()
+        else:
+            self._cache = cache
 
         # Optimizing savings calculations to optimize log generation
         self._recent_tokens_savings = 0


### PR DESCRIPTION
## Why are these changes needed?

The TextMessageCompressor's `cache` parameter for `__init__()` has a default value of `Cache.disk()`. This is causing it to run on import rather than just on instantiation.

This PR changes the default to `None` and the `Cache.disk()` is executed within `__init__`.

## Related issue number

Raised by @omarhurani,  #63 

## Checks

- [ ] I've included any doc changes needed for https://autogen-ai.github.io/autogen/. See https://autogen-ai.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [X] I've made sure all auto checks have passed.
