### PR TITLE
Prevent FLAML logging warning on import

### DIFF
--- a/autogen/oai/completion.py
+++ b/autogen/oai/completion.py
@@ -13,8 +13,18 @@ from time import sleep
 from typing import Callable, Dict, List, Optional, Union
 
 import numpy as np
+
+# Adding a NullHandler to silence FLAML log warning during
+# import
+flaml_logger = logging.getLogger("flaml")
+null_handler = logging.NullHandler()
+flaml_logger.addHandler(null_handler)
+
 from flaml import BlendSearch, tune
 from flaml.tune.space import is_constant
+
+# Restore logging by removing the NullHandler
+flaml_logger.removeHandler(null_handler)
 
 from .client_utils import logging_formatter
 from .openai_utils import get_key


### PR DESCRIPTION
## Why are these changes needed?

Previous FLAML PR (#61) did not fully remove the FLAML warning showing when running AutoGen workflows due to FLAML in `completion.py`.

So, this PR will add a temporary logging NullHandler during import of FLAML functions in `completion.py`, then will remove the NullHandler afterwards.

## Related issue number

#61

## Checks

- [ ] I've included any doc changes needed for https://autogen-ai.github.io/autogen/. See https://autogen-ai.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
