### PR TITLE
Update to docker tag names

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -10,21 +10,21 @@ These configurations can be used with Codespaces and locally.
 
 - **Purpose**: This Dockerfile, i.e., `./Dockerfile`, is designed for basic setups. It includes common Python libraries and essential dependencies required for general usage of AutoGen.
 - **Usage**: Ideal for those just starting with AutoGen or for general-purpose applications.
-- **Building the Image**: Run `docker build -f ./Dockerfile -t autogen_ai_base_img .` in this directory.
+- **Building the Image**: Run `docker build -f ./Dockerfile -t autogenhub_base_img .` in this directory.
 - **Using with Codespaces**: `Code > Codespaces > Click on +` By default + creates a Codespace on the current branch.
 
 ### full
 
 - **Purpose**: This Dockerfile, i.e., `./full/Dockerfile` is for advanced features. It includes additional dependencies and is configured for more complex or feature-rich AutoGen applications.
 - **Usage**: Suited for advanced users who need the full range of AutoGen's capabilities.
-- **Building the Image**: Execute `docker build -f full/Dockerfile -t autogen_ai_full_img .`.
+- **Building the Image**: Execute `docker build -f full/Dockerfile -t autogenhub_full_img .`.
 - **Using with Codespaces**: `Code > Codespaces > Click on ...> New with options > Choose "full" as devcontainer configuration`. This image may require a Codespace with at least 64GB of disk space.
 
 ### dev
 
 - **Purpose**: Tailored for AutoGen project developers, this Dockerfile, i.e., `./dev/Dockerfile` includes tools and configurations aiding in development and contribution.
 - **Usage**: Recommended for developers who are contributing to the AutoGen project.
-- **Building the Image**: Run `docker build -f dev/Dockerfile -t autogen_ai_dev_img .`.
+- **Building the Image**: Run `docker build -f dev/Dockerfile -t autogenhub_dev_img .`.
 - **Using with Codespaces**: `Code > Codespaces > Click on ...> New with options > Choose "dev" as devcontainer configuration`. This image may require a Codespace with at least 64GB of disk space.
 - **Before using**: We highly encourage all potential contributors to read the [AutoGen Contributing](https://autogenhub.github.io/autogen/docs/Contribute) page prior to submitting any pull requests.
 

--- a/website/docs/contributor-guide/docker.md
+++ b/website/docs/contributor-guide/docker.md
@@ -2,9 +2,9 @@
 
 For developers contributing to the AutoGen project, we offer a specialized Docker environment. This setup is designed to streamline the development process, ensuring that all contributors work within a consistent and well-equipped environment.
 
-## Autogen Developer Image (autogen_ai_dev_img)
+## Autogen Developer Image (autogenhub_dev_img)
 
-- **Purpose**: The `autogen_ai_dev_img` is tailored for contributors to the AutoGen project. It includes a suite of tools and configurations that aid in the development and testing of new features or fixes.
+- **Purpose**: The `autogenhub_dev_img` is tailored for contributors to the AutoGen project. It includes a suite of tools and configurations that aid in the development and testing of new features or fixes.
 - **Usage**: This image is recommended for developers who intend to contribute code or documentation to AutoGen.
 - **Forking the Project**: It's advisable to fork the AutoGen GitHub project to your own repository. This allows you to make changes in a separate environment without affecting the main project.
 - **Updating Dockerfile**: Modify your copy of `Dockerfile` in the `dev` folder as needed for your development work.
@@ -12,10 +12,10 @@ For developers contributing to the AutoGen project, we offer a specialized Docke
 
 ## Building the Developer Docker Image
 
-- To build the developer Docker image (`autogen_ai_dev_img`), use the following commands:
+- To build the developer Docker image (`autogenhub_dev_img`), use the following commands:
 
   ```bash
-  docker build -f .devcontainer/dev/Dockerfile -t autogen_ai_dev_img https://github.com/autogenhub/autogen.git#main
+  docker build -f .devcontainer/dev/Dockerfile -t autogenhub_dev_img https://github.com/autogenhub/autogen.git#main
   ```
 
 - For building the developer image built from a specific Dockerfile in a branch other than main/master
@@ -33,16 +33,16 @@ For developers contributing to the AutoGen project, we offer a specialized Docke
 
 ## Using the Developer Docker Image
 
-Once you have built the `autogen_ai_dev_img`, you can run it using the standard Docker commands. This will place you inside the containerized development environment where you can run tests, develop code, and ensure everything is functioning as expected before submitting your contributions.
+Once you have built the `autogenhub_dev_img`, you can run it using the standard Docker commands. This will place you inside the containerized development environment where you can run tests, develop code, and ensure everything is functioning as expected before submitting your contributions.
 
 ```bash
-docker run -it -p 8081:3000 -v `pwd`/autogen-newcode:newstuff/ autogen_ai_dev_img bash
+docker run -it -p 8081:3000 -v `pwd`/autogen-newcode:newstuff/ autogenhub_dev_img bash
 ```
 
 - Note that the `pwd` is shorthand for present working directory. Thus, any path after the pwd is relative to that. If you want a more verbose method you could remove the "`pwd`/autogen-newcode" and replace it with the full path to your directory
 
 ```bash
-docker run -it -p 8081:3000 -v /home/AutoGenDeveloper/autogen-newcode:newstuff/ autogen_ai_dev_img bash
+docker run -it -p 8081:3000 -v /home/AutoGenDeveloper/autogen-newcode:newstuff/ autogenhub_dev_img bash
 ```
 
 ## Develop in Remote Container

--- a/website/docs/contributor-guide/documentation.md
+++ b/website/docs/contributor-guide/documentation.md
@@ -39,13 +39,13 @@ Most changes are reflected live without having to restart the server.
 To build and test documentation within a docker container. Use the Dockerfile in the `dev` folder as described above to build your image:
 
 ```bash
-docker build -f .devcontainer/dev/Dockerfile -t autogen_ai_dev_img https://github.com/autogenhub/autogen.git#main
+docker build -f .devcontainer/dev/Dockerfile -t autogenhub_dev_img https://github.com/autogenhub/autogen.git#main
 ```
 
 Then start the container like so, this will log you in and ensure that Docker port 3000 is mapped to port 8081 on your local machine
 
 ```bash
-docker run -it -p 8081:3000 -v `pwd`/autogen-newcode:newstuff/ autogen_ai_dev_img bash
+docker run -it -p 8081:3000 -v `pwd`/autogen-newcode:newstuff/ autogenhub_dev_img bash
 ```
 
 Once at the CLI in Docker run the following commands:

--- a/website/docs/installation/Docker.md
+++ b/website/docs/installation/Docker.md
@@ -4,8 +4,8 @@ Docker, an indispensable tool in modern software development, offers a compellin
 
 **Pre-configured DockerFiles**: The AutoGen Project offers pre-configured Dockerfiles for your use. These Dockerfiles will run as is, however they can be modified to suit your development needs. Please see the README.md file in autogen/.devcontainer
 
-- **autogen_ai_base_img**: For a basic setup, you can use the `autogen_ai_base_img` to run simple scripts or applications. This is ideal for general users or those new to AutoGen.
-- **autogen_ai_full_img**: Advanced users or those requiring more features can use `autogen_ai_full_img`. Be aware that this version loads ALL THE THINGS and thus is very large. Take this into consideration if you build your application off of it.
+- **autogenhub_base_img**: For a basic setup, you can use the `autogenhub_base_img` to run simple scripts or applications. This is ideal for general users or those new to AutoGen.
+- **autogenhub_full_img**: Advanced users or those requiring more features can use `autogenhub_full_img`. Be aware that this version loads ALL THE THINGS and thus is very large. Take this into consideration if you build your application off of it.
 
 ## Step 1: Install Docker
 
@@ -20,13 +20,13 @@ AutoGen now provides updated Dockerfiles tailored for different needs. Building 
 - **Autogen Basic**: Ideal for general use, this setup includes common Python libraries and essential dependencies. Perfect for those just starting with AutoGen.
 
   ```bash
-  docker build -f .devcontainer/Dockerfile -t autogen_ai_base_img https://github.com/autogenhub/autogen.git#main
+  docker build -f .devcontainer/Dockerfile -t autogenhub_base_img https://github.com/autogenhub/autogen.git#main
   ```
 
-- **Autogen Advanced**: Advanced users or those requiring all the things that AutoGen has to offer `autogen_ai_full_img`
+- **Autogen Advanced**: Advanced users or those requiring all the things that AutoGen has to offer `autogenhub_full_img`
 
   ```bash
-  docker build -f .devcontainer/full/Dockerfile -t autogen_ai_full_img https://github.com/autogenhub/autogen.git#main
+  docker build -f .devcontainer/full/Dockerfile -t autogenhub_full_img https://github.com/autogenhub/autogen.git#main
   ```
 
 ## Step 3: Run AutoGen Applications from Docker Image
@@ -36,7 +36,7 @@ Here's how you can run an application built with AutoGen, using the Docker image
 1. **Mount Your Directory**: Use the Docker `-v` flag to mount your local application directory to the Docker container. This allows you to develop on your local machine while running the code in a consistent Docker environment. For example:
 
    ```bash
-   docker run -it -v $(pwd)/myapp:/home/autogenhub/autogen/myapp autogen_ai_base_img:latest python /home/autogenhub/autogen/myapp/main.py
+   docker run -it -v $(pwd)/myapp:/home/autogenhub/autogen/myapp autogenhub_base_img:latest python /home/autogenhub/autogen/myapp/main.py
    ```
 
    Here, `$(pwd)/myapp` is your local directory, and `/home/autogenhub/autogen/myapp` is the path in the Docker container where your code will be located.
@@ -45,13 +45,13 @@ Here's how you can run an application built with AutoGen, using the Docker image
 
    ```python
    # Mount the local folder `myapp` into docker image and run the script named "twoagent.py" in the docker.
-   docker run -it -v `pwd`/myapp:/myapp autogen_ai_base_img:latest python /myapp/main_twoagent.py
+   docker run -it -v `pwd`/myapp:/myapp autogenhub_base_img:latest python /myapp/main_twoagent.py
    ```
 
 3. **Port Mapping**: If your application requires a specific port, use the `-p` flag to map the container's port to your host. For instance, if your app runs on port 3000 inside Docker and you want it accessible on port 8080 on your host machine:
 
    ```bash
-   docker run -it -p 8080:3000 -v $(pwd)/myapp:/myapp autogen_ai_base_img:latest python /myapp
+   docker run -it -p 8080:3000 -v $(pwd)/myapp:/myapp autogenhub_base_img:latest python /myapp
    ```
 
    In this command, `-p 8080:3000` maps port 3000 from the container to port 8080 on your local machine.
@@ -65,19 +65,19 @@ docker run -it -p {WorkstationPortNum}:{DockerPortNum} -v {WorkStation_Dir}:{Doc
 - _Simple Script_: Run a Python script located in your local `myapp` directory.
 
   ```bash
-  docker run -it -v `pwd`/myapp:/myapp autogen_ai_base_img:latest python /myapp/my_script.py
+  docker run -it -v `pwd`/myapp:/myapp autogenhub_base_img:latest python /myapp/my_script.py
   ```
 
 - _Web Application_: If your application includes a web server running on port 5000.
 
   ```bash
-  docker run -it -p 8080:5000 -v $(pwd)/myapp:/myapp autogen_ai_base_img:latest
+  docker run -it -p 8080:5000 -v $(pwd)/myapp:/myapp autogenhub_base_img:latest
   ```
 
 - _Data Processing_: For tasks that involve processing data stored in a local directory.
 
   ```bash
-  docker run -it -v $(pwd)/data:/data autogen_ai_base_img:latest python /myapp/process_data.py
+  docker run -it -v $(pwd)/data:/data autogenhub_base_img:latest python /myapp/process_data.py
   ```
 
 ## Additional Resources


### PR DESCRIPTION
## Why are these changes needed?

Updating tag names for the Docker images so that `autogen_ai_[...]` is `autogenhub_[...]`.

Tag names are now:
`autogenhub_base_img`
`autogenhub_dev_img`
`autogenhub_full_img`

## Related issue number

None

## Checks

- [ ] I've included any doc changes needed for https://autogenhub.github.io/autogen/. See https://autogenhub.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [ ] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [ ] I've made sure all auto checks have passed.
