### PR TITLE
Bren

### DIFF
--- a/autogen/agentchat/__init__.py
+++ b/autogen/agentchat/__init__.py
@@ -24,5 +24,5 @@ __all__ = (
     "initiate_chats",
     "gather_usage_summary",
     "ChatResult",
-    "CustomNestedChatCondition"
+    "CustomNestedChatCondition",
 )

--- a/autogen/agentchat/__init__.py
+++ b/autogen/agentchat/__init__.py
@@ -11,6 +11,7 @@ from .conversable_agent import ConversableAgent, register_function
 from .groupchat import GroupChat, GroupChatManager
 from .user_proxy_agent import UserProxyAgent
 from .utils import gather_usage_summary
+from .custom_nested_chat_condition import CustomNestedChatCondition
 
 __all__ = (
     "Agent",
@@ -23,4 +24,5 @@ __all__ = (
     "initiate_chats",
     "gather_usage_summary",
     "ChatResult",
+    "CustomNestedChatCondition"
 )

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -40,6 +40,7 @@ from ..io.base import IOStream
 from ..oai.client import ModelClient, OpenAIWrapper
 from ..runtime_logging import log_event, log_function_use, log_new_agent, logging_enabled
 from .agent import Agent, LLMAgent
+from .custom_nested_chat_condition import CustomNestedChatCondition
 from .chat import ChatResult, a_initiate_chats, initiate_chats
 from .utils import consolidate_chat_info, gather_usage_summary
 
@@ -2159,6 +2160,12 @@ class ConversableAgent(LLMAgent):
             return trigger == sender
         elif isinstance(trigger, Callable):
             rst = trigger(sender)
+            assert isinstance(rst, bool), f"trigger {trigger} must return a boolean value."
+            return rst
+        elif isinstance(trigger, CustomNestedChatCondition):
+            rst = trigger.call_function()
+            if trigger.state_params is not None:
+                trigger.call_function
             assert isinstance(rst, bool), f"trigger {trigger} must return a boolean value."
             return rst
         elif isinstance(trigger, list):

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -40,8 +40,8 @@ from ..io.base import IOStream
 from ..oai.client import ModelClient, OpenAIWrapper
 from ..runtime_logging import log_event, log_function_use, log_new_agent, logging_enabled
 from .agent import Agent, LLMAgent
-from .custom_nested_chat_condition import CustomNestedChatCondition
 from .chat import ChatResult, a_initiate_chats, initiate_chats
+from .custom_nested_chat_condition import CustomNestedChatCondition
 from .utils import consolidate_chat_info, gather_usage_summary
 
 __all__ = ("ConversableAgent",)
@@ -357,7 +357,9 @@ class ConversableAgent(LLMAgent):
             remove_other_reply_funcs (bool): whether to remove other reply functions when registering this reply function.
         """
         if not isinstance(trigger, (type, str, Agent, Callable, list, CustomNestedChatCondition)):
-            raise ValueError("trigger must be a class, a string, an agent, a callable, CustomNestedChatCondition or a list.")
+            raise ValueError(
+                "trigger must be a class, a string, an agent, a callable, CustomNestedChatCondition or a list."
+            )
         if remove_other_reply_funcs:
             self._reply_func_list.clear()
         self._reply_func_list.insert(

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -302,7 +302,7 @@ class ConversableAgent(LLMAgent):
 
     def register_reply(
         self,
-        trigger: Union[Type[Agent], str, Agent, Callable[[Agent], bool], List],
+        trigger: Union[Type[Agent], str, Agent, Callable[[Agent], bool], CustomNestedChatCondition, List],
         reply_func: Callable,
         position: int = 0,
         config: Optional[Any] = None,

--- a/autogen/agentchat/conversable_agent.py
+++ b/autogen/agentchat/conversable_agent.py
@@ -356,8 +356,8 @@ class ConversableAgent(LLMAgent):
                 function.
             remove_other_reply_funcs (bool): whether to remove other reply functions when registering this reply function.
         """
-        if not isinstance(trigger, (type, str, Agent, Callable, list)):
-            raise ValueError("trigger must be a class, a string, an agent, a callable or a list.")
+        if not isinstance(trigger, (type, str, Agent, Callable, list, CustomNestedChatCondition)):
+            raise ValueError("trigger must be a class, a string, an agent, a callable, CustomNestedChatCondition or a list.")
         if remove_other_reply_funcs:
             self._reply_func_list.clear()
         self._reply_func_list.insert(

--- a/autogen/agentchat/custom_nested_chat_condition.py
+++ b/autogen/agentchat/custom_nested_chat_condition.py
@@ -10,6 +10,9 @@ class CustomNestedChatCondition():
         Args:
             func: A callable function defined by the user.
             params: A dictionary of variables and names to act as the func's parameters.
+            name: Optional string to name the custom condition. if none given, it will use the func.__name__ value
+            off_switch: Testing shows that once once the condition is set to true, it needs to be switched off or else it remains true and will always be true. Therefore, control over when to turn off nested chats needs to be specified. "immediate" for one-and-done nested chats, "recurring_condition" for something that may happen regularly, "temporary_attention_switch" for if you need to get more information outside the chat from somewhere else
+            
         """
         # ennforce func is callable that returns bool
         if not callable(func):
@@ -60,7 +63,3 @@ class CustomNestedChatCondition():
                 raise TypeError(f"Parameter '{new_param_value}' has type of {type(new_param_value)}should be of type {type(self.state_params["new_param_name"])}")
             else:
                 self.state_params["new_param_name"] = new_param_value
-
-
-
-        

--- a/autogen/agentchat/custom_nested_chat_condition.py
+++ b/autogen/agentchat/custom_nested_chat_condition.py
@@ -1,0 +1,66 @@
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, TypeVar, Union, get_type_hints
+import inspect
+class CustomNestedChatCondition():
+    def __init__(self,
+                 func: Callable[..., bool],
+                 state_params: Optional[dict[str, Any]]=None,
+                 name: Optional[str] = None):
+        """Class to hold a user-defined function signature and its parameters to act as conditions for nested conversations.
+        
+        Args:
+            func: A callable function defined by the user.
+            params: A dictionary of variables and names to act as the func's parameters.
+        """
+        # ennforce func is callable that returns bool
+        if not callable(func):
+            raise ValueError("Function must be callable type that returns bool.")
+        sig = inspect.signature(func)
+        try:
+            # Check if func can be called without arguments, and test if it returns a boolean
+            result = func(*[None] * len(sig.parameters))  # Call func with default None args for demo
+            if not isinstance(result, bool):
+                raise TypeError(f"The function '{func.__name__}' must return a boolean value.")
+        except TypeError:
+            pass  # Ignore if the function can't be called without arguments (further checking may be necessary)
+        
+        self.func = func           # Store the function itself
+        self.state_params = state_params       # Store the parameter names as a list
+        if name:
+            self._name = name
+        else:
+            self._name = func.__name__
+        
+        # iterate over items in params and sig.parameters, ensure a 1:1 match between them based on key of params and name of sig.params and data type
+        type_hints = get_type_hints(self.func)
+        for param_name, param in sig.parameters.items():
+            # Check if the parameter exists in the provided params
+            if param_name not in self.state_params:
+                raise ValueError(f"Parameter '{param_name}' is required by the function '{self.func.__name__}' but was not provided in params.")
+            # Ensure that type of func param is same as that of self.params counterpart
+            expected_type = type_hints.get(param_name, Any)
+            if not isinstance(self.state_params[param_name], expected_type) and expected_type is not Any:
+                raise TypeError(f"Parameter '{param_name}' should be of type {expected_type}, but got {type(self.state_params[param_name])}")
+            
+    def call_function(self):
+        """
+        Call the function using the provided params, matching by parameter name.
+        """
+        # Call the function using **params to match by parameter name
+        return self.func(**self.state_params)
+            
+    def update_state(self, new_state: dict):
+        """
+        Takes dictionary where key is variable name and value is new value. New value must be same type as original value or else error will be thrown. Unrecognised keys will be ignored
+        """
+        for new_param_name, new_param_value in new_state.items():
+            if self.state_params.get(new_param_name, None) == None:
+                # Warning of some kind
+                continue
+            if not isinstance(new_param_value, type(self.state_params["new_param_name"])):
+                raise TypeError(f"Parameter '{new_param_value}' has type of {type(new_param_value)}should be of type {type(self.state_params["new_param_name"])}")
+            else:
+                self.state_params["new_param_name"] = new_param_value
+
+
+
+        

--- a/autogen/agentchat/custom_nested_chat_condition.py
+++ b/autogen/agentchat/custom_nested_chat_condition.py
@@ -2,12 +2,14 @@ import inspect
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, TypeVar, Union, get_type_hints
 
 
-class CustomNestedChatCondition():
-    def __init__(self,
-                 func: Callable[..., bool],
-                 state_params: Optional[dict[str, Any]]=None,
-                 name: Optional[str] = None,
-                 state_ttl_management: Literal["STATELESS", "STATE_KEPT_TILL_TRUE", "STATE_KEPT_TILL_FALSE"] = "STATELESS"):
+class CustomNestedChatCondition:
+    def __init__(
+        self,
+        func: Callable[..., bool],
+        state_params: Optional[dict[str, Any]] = None,
+        name: Optional[str] = None,
+        state_ttl_management: Literal["STATELESS", "STATE_KEPT_TILL_TRUE", "STATE_KEPT_TILL_FALSE"] = "STATELESS",
+    ):
         """Class to hold a user-defined function signature and its parameters to act as conditions for nested conversations.
 
         Args:
@@ -20,32 +22,32 @@ class CustomNestedChatCondition():
                 The following 2 enum values are for scenarios where the trigger function needs to work with runtime state variables and external data that changes by itself. Should the developer need the runtime state data to work with that external data, this should provide that support
                 (2) When "STATE_KEPT_TILL_TRUE", the state will be kept as-is until trigger function returns true, whereby it will be reset to None.
                 (3) When "STATE_KEPT_TILL_FALSE", the state will be kept as-is until trigger function returns false, whereby it will be reset to None.
-            
+
         """
 
-        self.func = func # Store the function itself
-        self.state_params = state_params # Store the parameter names as a dict
+        self.func = func  # Store the function itself
+        self.state_params = state_params  # Store the parameter names as a dict
         if name:
             self._name = name
         else:
             self._name = func.__name__
 
-        self.state_ttl_management=state_ttl_management
+        self.state_ttl_management = state_ttl_management
 
         # ennforce func is callable that returns bool
         if not callable(func):
-            raise ValueError(
-                "Function must be callable type that returns bool."
-            )
+            raise ValueError("Function must be callable type that returns bool.")
         sig = inspect.signature(func)
         type_hints = get_type_hints(self.func)
-        if (len(sig.parameters.items()) > 0):
+        if len(sig.parameters.items()) > 0:
             self.func_has_params = True
             # iterate over items in params and sig.parameters, ensure a 1:1 match between them based on key of params and name of sig.params and data type
             for param_name, param in sig.parameters.items():
                 # Check if the parameter exists in the provided params
                 if param_name not in self.state_params:
-                    raise ValueError(f"Parameter '{param_name}' is required by the function '{self.func.__name__}' but was not provided in params.")
+                    raise ValueError(
+                        f"Parameter '{param_name}' is required by the function '{self.func.__name__}' but was not provided in params."
+                    )
                 # Ensure that type of func param is same as that of self.params counterpart
                 expected_type = type_hints.get(param_name, Any)
                 if not isinstance(self.state_params[param_name], expected_type) and expected_type is not Any:
@@ -59,9 +61,7 @@ class CustomNestedChatCondition():
             # Check if func returns a boolean
             result = func(*[None] * len(sig.parameters))  # Call func with default None args for demo
             if not isinstance(result, bool):
-                raise TypeError(
-                    f"The function '{func.__name__}' must return a boolean value."
-                )
+                raise TypeError(f"The function '{func.__name__}' must return a boolean value.")
         except TypeError:
             pass  # Ignore if the function can't be called without arguments (further checking may be necessary)
 
@@ -71,9 +71,7 @@ class CustomNestedChatCondition():
         """
         # Call the function using **params to match by parameter name
         if self.func_has_params and self.state_params == None:
-            raise TypeError(
-                f"{self._name} is missing parameters"
-            )
+            raise TypeError(f"{self._name} is missing parameters")
             return False
         trigger_result = self.func(**self.state_params)
 

--- a/autogen/agentchat/custom_nested_chat_condition.py
+++ b/autogen/agentchat/custom_nested_chat_condition.py
@@ -4,7 +4,8 @@ class CustomNestedChatCondition():
     def __init__(self,
                  func: Callable[..., bool],
                  state_params: Optional[dict[str, Any]]=None,
-                 name: Optional[str] = None):
+                 name: Optional[str] = None,
+                 state_ttl_management: Literal["STATELESS", "STATE_KEPT_TILL_TRUE", "STATE_KEPT_TILL_FALSE"] = "STATELESS"):
         """Class to hold a user-defined function signature and its parameters to act as conditions for nested conversations.
         
         Args:
@@ -13,47 +14,57 @@ class CustomNestedChatCondition():
             name (str): Optional string to name the custom condition. if none given, it will use the func.__name__ value
             state_ttl_management (str): The time-to-live for the state of the parameters needs to change or else the nested chat will forever be triggered. 
                 Possible values are "STATELESS", "PERSISTENT",
-                (1) When "STATELESS", the state_params will be reset to an empty dict immediately after the trigger is checked.
+                (1) When "STATELESS", the state_params will be reset to an empty dict immediately after the trigger is checked, until then it will remain.
                 The following 2 enum values are for scenarios where the trigger function needs to work with runtime state variables and external data that changes by itself. Should the developer need the runtime state data to work with that external data, this should provide that support
                 (2) When "STATE_KEPT_TILL_TRUE", the state will be kept as-is until trigger function returns true, whereby it will be reset to None.
                 (3) When "STATE_KEPT_TILL_FALSE", the state will be kept as-is until trigger function returns false, whereby it will be reset to None.
             
         """
+        
+        self.func = func # Store the function itself
+        self.state_params = state_params # Store the parameter names as a dict
+        if name:
+            self._name = name
+        else:
+            self._name = func.__name__
+
+        self.state_ttl_management=state_ttl_management
+
         # ennforce func is callable that returns bool
         if not callable(func):
             raise ValueError("Function must be callable type that returns bool.")
         sig = inspect.signature(func)
+        type_hints = get_type_hints(self.func)
+        if (len(sig.parameters.items()) > 0):
+            self.func_has_params = True
+            # iterate over items in params and sig.parameters, ensure a 1:1 match between them based on key of params and name of sig.params and data type
+            for param_name, param in sig.parameters.items():
+                # Check if the parameter exists in the provided params
+                if param_name not in self.state_params:
+                    raise ValueError(f"Parameter '{param_name}' is required by the function '{self.func.__name__}' but was not provided in params.")
+                # Ensure that type of func param is same as that of self.params counterpart
+                expected_type = type_hints.get(param_name, Any)
+                if not isinstance(self.state_params[param_name], expected_type) and expected_type is not Any:
+                    raise TypeError(f"Parameter '{param_name}' should be of type {expected_type}, but got {type(self.state_params[param_name])}")
+        else:
+            self.func_has_params = False
+        
         try:
-            # Check if func can be called without arguments, and test if it returns a boolean
+            # Check if func returns a boolean
             result = func(*[None] * len(sig.parameters))  # Call func with default None args for demo
             if not isinstance(result, bool):
                 raise TypeError(f"The function '{func.__name__}' must return a boolean value.")
         except TypeError:
             pass  # Ignore if the function can't be called without arguments (further checking may be necessary)
-        
-        self.func = func           # Store the function itself
-        self.state_params = state_params       # Store the parameter names as a dict
-        if name:
-            self._name = name
-        else:
-            self._name = func.__name__
-        
-        # iterate over items in params and sig.parameters, ensure a 1:1 match between them based on key of params and name of sig.params and data type
-        type_hints = get_type_hints(self.func)
-        for param_name, param in sig.parameters.items():
-            # Check if the parameter exists in the provided params
-            if param_name not in self.state_params:
-                raise ValueError(f"Parameter '{param_name}' is required by the function '{self.func.__name__}' but was not provided in params.")
-            # Ensure that type of func param is same as that of self.params counterpart
-            expected_type = type_hints.get(param_name, Any)
-            if not isinstance(self.state_params[param_name], expected_type) and expected_type is not Any:
-                raise TypeError(f"Parameter '{param_name}' should be of type {expected_type}, but got {type(self.state_params[param_name])}")
             
     def call_function(self):
         """
         Call the function using the provided params, matching by parameter name.
         """
         # Call the function using **params to match by parameter name
+        if self.func_has_params and self.state_params == None:
+            raise TypeError(f"{self._name} is missing parameters")
+            return False
         trigger_result = self.func(**self.state_params)
         
         # Handle state_params reset based on state_ttl_management

--- a/autogen/agentchat/custom_nested_chat_condition.py
+++ b/autogen/agentchat/custom_nested_chat_condition.py
@@ -27,7 +27,7 @@ class CustomNestedChatCondition():
             pass  # Ignore if the function can't be called without arguments (further checking may be necessary)
         
         self.func = func           # Store the function itself
-        self.state_params = state_params       # Store the parameter names as a list
+        self.state_params = state_params       # Store the parameter names as a dict
         if name:
             self._name = name
         else:
@@ -49,7 +49,9 @@ class CustomNestedChatCondition():
         Call the function using the provided params, matching by parameter name.
         """
         # Call the function using **params to match by parameter name
-        return self.func(**self.state_params)
+        result = self.func(**self.state_params)
+        self.state_params=None
+        return result
             
     def update_state(self, new_state: dict):
         """

--- a/autogen/agentchat/custom_nested_chat_condition.py
+++ b/autogen/agentchat/custom_nested_chat_condition.py
@@ -1,5 +1,7 @@
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, TypeVar, Union, get_type_hints
 import inspect
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, TypeVar, Union, get_type_hints
+
+
 class CustomNestedChatCondition():
     def __init__(self,
                  func: Callable[..., bool],
@@ -7,12 +9,12 @@ class CustomNestedChatCondition():
                  name: Optional[str] = None,
                  state_ttl_management: Literal["STATELESS", "STATE_KEPT_TILL_TRUE", "STATE_KEPT_TILL_FALSE"] = "STATELESS"):
         """Class to hold a user-defined function signature and its parameters to act as conditions for nested conversations.
-        
+
         Args:
             func (Callable): A callable function defined by the user.
             params (Dict): A dictionary of variables and names to act as the func's parameters.
             name (str): Optional string to name the custom condition. if none given, it will use the func.__name__ value
-            state_ttl_management (str): The time-to-live for the state of the parameters needs to change or else the nested chat will forever be triggered. 
+            state_ttl_management (str): The time-to-live for the state of the parameters needs to change or else the nested chat will forever be triggered.
                 Possible values are "STATELESS", "PERSISTENT",
                 (1) When "STATELESS", the state_params will be reset to an empty dict immediately after the trigger is checked, until then it will remain.
                 The following 2 enum values are for scenarios where the trigger function needs to work with runtime state variables and external data that changes by itself. Should the developer need the runtime state data to work with that external data, this should provide that support
@@ -20,7 +22,7 @@ class CustomNestedChatCondition():
                 (3) When "STATE_KEPT_TILL_FALSE", the state will be kept as-is until trigger function returns false, whereby it will be reset to None.
             
         """
-        
+
         self.func = func # Store the function itself
         self.state_params = state_params # Store the parameter names as a dict
         if name:
@@ -32,7 +34,9 @@ class CustomNestedChatCondition():
 
         # ennforce func is callable that returns bool
         if not callable(func):
-            raise ValueError("Function must be callable type that returns bool.")
+            raise ValueError(
+                "Function must be callable type that returns bool."
+            )
         sig = inspect.signature(func)
         type_hints = get_type_hints(self.func)
         if (len(sig.parameters.items()) > 0):
@@ -45,28 +49,34 @@ class CustomNestedChatCondition():
                 # Ensure that type of func param is same as that of self.params counterpart
                 expected_type = type_hints.get(param_name, Any)
                 if not isinstance(self.state_params[param_name], expected_type) and expected_type is not Any:
-                    raise TypeError(f"Parameter '{param_name}' should be of type {expected_type}, but got {type(self.state_params[param_name])}")
+                    raise TypeError(
+                        f"Parameter '{param_name}' should be of type {expected_type}, but got {type(self.state_params[param_name])}"
+                    )
         else:
             self.func_has_params = False
-        
+
         try:
             # Check if func returns a boolean
             result = func(*[None] * len(sig.parameters))  # Call func with default None args for demo
             if not isinstance(result, bool):
-                raise TypeError(f"The function '{func.__name__}' must return a boolean value.")
+                raise TypeError(
+                    f"The function '{func.__name__}' must return a boolean value."
+                )
         except TypeError:
             pass  # Ignore if the function can't be called without arguments (further checking may be necessary)
-            
+
     def call_function(self):
         """
         Call the function using the provided params, matching by parameter name.
         """
         # Call the function using **params to match by parameter name
         if self.func_has_params and self.state_params == None:
-            raise TypeError(f"{self._name} is missing parameters")
+            raise TypeError(
+                f"{self._name} is missing parameters"
+            )
             return False
         trigger_result = self.func(**self.state_params)
-        
+
         # Handle state_params reset based on state_ttl_management
         if self.state_ttl_management == "STATELESS":
             # Reset state_params to an empty dict immediately after the trigger is checked
@@ -85,7 +95,6 @@ class CustomNestedChatCondition():
 
         return trigger_result
 
-            
     def update_state(self, new_state: dict):
         """
         Takes dictionary where key is variable name and value is new value. New value must be same type as original value or else error will be thrown. Unrecognised keys will be ignored
@@ -95,6 +104,8 @@ class CustomNestedChatCondition():
                 # Warning of some kind
                 continue
             if not isinstance(new_param_value, type(self.state_params["new_param_name"])):
-                raise TypeError(f"Parameter '{new_param_value}' has type of {type(new_param_value)}should be of type {type(self.state_params["new_param_name"])}")
+                raise TypeError(
+                    f"Parameter '{new_param_value}' has type of {type(new_param_value)}should be of type {type(self.state_params["new_param_name"])}"
+                )
             else:
                 self.state_params["new_param_name"] = new_param_value

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -22,7 +22,7 @@ from test_assistant_agent import KEY_LOC, OAI_CONFIG_LIST
 from typing_extensions import Annotated
 
 import autogen
-from autogen.agentchat import ConversableAgent, UserProxyAgent, CustomNestedChatCondition
+from autogen.agentchat import ConversableAgent, CustomNestedChatCondition, UserProxyAgent
 from autogen.agentchat.conversable_agent import register_function
 from autogen.exception_utils import InvalidCarryOverType, SenderRequired
 
@@ -91,14 +91,12 @@ def test_sync_trigger():
     # Test user defined with trigger
     def user_defined_trigger():
         return True
-    nested_chat_condition = CustomNestedChatCondition(
-        func=user_defined_trigger
-    )
-    agent.register_reply(
-        nested_chat_condition, lambda recipient, messages, sender, config: (True, "hello agent1")
-    )
+
+    nested_chat_condition = CustomNestedChatCondition(func=user_defined_trigger)
+    agent.register_reply(nested_chat_condition, lambda recipient, messages, sender, config: (True, "hello agent1"))
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello agent1"
+
     # Test user defined trigger with params (default state management: STATELESS)
     # Test with blank slate agents
     def user_defined_trigger_with_params(f: int):
@@ -106,49 +104,42 @@ def test_sync_trigger():
             return True
         else:
             return False
-    nested_chat_condition_state = {
-        "f":1
-    }
+
+    nested_chat_condition_state = {"f": 1}
     nested_chat_condition = CustomNestedChatCondition(
-        func=user_defined_trigger_with_params,
-        state_params=nested_chat_condition_state
+        func=user_defined_trigger_with_params, state_params=nested_chat_condition_state
     )
     agent = ConversableAgent("a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
     agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
-    agent.register_reply(
-        nested_chat_condition, lambda recipient, messages, sender, config: (True, "hello agent1")
-    )
+    agent.register_reply(nested_chat_condition, lambda recipient, messages, sender, config: (True, "hello agent1"))
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello agent1"
     # Now that trigger has been activated, state should reset to None, and initiating chat aain would fail
     agent1.initiate_chat(agent, message="hi")
-    assert agent1.last_message(agent) == None #is there another bettter way to assert agent1 wont reply?
+    assert agent1.last_message(agent) == None  # is there another bettter way to assert agent1 wont reply?
 
     # Test user defined trigger with params (default state management: STATE_KEPT_TILL_TRUE)
     # Test with blank slate agents
-    nested_chat_condition.state_ttl_management="STATE_KEPT_TILL_TRUE"
-    agent.register_reply(
-        nested_chat_condition, lambda recipient, messages, sender, config: (True, "hello agent1")
-    )
+    nested_chat_condition.state_ttl_management = "STATE_KEPT_TILL_TRUE"
+    agent.register_reply(nested_chat_condition, lambda recipient, messages, sender, config: (True, "hello agent1"))
     agent1.initiate_chat(agent, message="hi")
     assert agent1.last_message(agent)["content"] == "hello agent1"
     # Now that trigger has been activated, state should reset to None, and initiating chat aain would fail
     agent1.initiate_chat(agent, message="hi")
-    assert agent1.last_message(agent) == None and nested_chat_condition.state_params == None #is there another bettter way to assert agent1 wont reply?
+    assert (
+        agent1.last_message(agent) == None and nested_chat_condition.state_params == None
+    )  # is there another bettter way to assert agent1 wont reply?
     # Test user defined trigger with params (default state management: STATE_KEPT_TILL_FALSE)
     # Test with blank slate agents
-    nested_chat_condition.state_ttl_management="STATE_KEPT_TILL_FALSE"
-    nested_chat_condition.update_state({
-        "f":-1
-    })
+    nested_chat_condition.state_ttl_management = "STATE_KEPT_TILL_FALSE"
+    nested_chat_condition.update_state({"f": -1})
     agent = ConversableAgent("a0", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
     agent1 = ConversableAgent("a1", max_consecutive_auto_reply=0, llm_config=False, human_input_mode="NEVER")
-    agent.register_reply(
-        nested_chat_condition, lambda recipient, messages, sender, config: (True, "hello agent1")
-    )
+    agent.register_reply(nested_chat_condition, lambda recipient, messages, sender, config: (True, "hello agent1"))
     agent1.initiate_chat(agent, message="hi")
     # Now that trigger has been failed, state should reset to None
     assert agent1.last_message(agent) == None and nested_chat_condition.state_params == None
+
 
 @pytest.mark.asyncio
 async def test_async_trigger():

--- a/test/agentchat/test_conversable_agent.py
+++ b/test/agentchat/test_conversable_agent.py
@@ -116,7 +116,7 @@ def test_sync_trigger():
     assert agent1.last_message(agent)["content"] == "hello agent1"
     # Now that trigger has been activated, state should reset to None, and initiating chat aain would fail
     agent1.initiate_chat(agent, message="hi")
-    assert agent1.last_message(agent) == None  # is there another bettter way to assert agent1 wont reply?
+    assert agent1.last_message(agent) == None  # is there another better way to assert agent1 won't reply?
 
     # Test user defined trigger with params (default state management: STATE_KEPT_TILL_TRUE)
     # Test with blank slate agents
@@ -128,7 +128,7 @@ def test_sync_trigger():
     agent1.initiate_chat(agent, message="hi")
     assert (
         agent1.last_message(agent) == None and nested_chat_condition.state_params == None
-    )  # is there another bettter way to assert agent1 wont reply?
+    )  # is there another better way to assert agent1 won't reply?
     # Test user defined trigger with params (default state management: STATE_KEPT_TILL_FALSE)
     # Test with blank slate agents
     nested_chat_condition.state_ttl_management = "STATE_KEPT_TILL_FALSE"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://autogenhub.github.io/autogen/docs/Contribute before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
I see that the code that handles the activation of nested chats only accepts the a Callable that only takes 1 parameter, the sender

elif isinstance(trigger, Callable): rst = trigger(sender) assert isinstance(rst, bool), f"trigger {trigger} must return a boolean value." return rst

I want to give devs more flexibility to decide when to have Agents initiate nested chats. 
EG.1 (Poor example due to code runner already existing as a part of some old version of GPT)
~the user proxy tells a code_writer agent that they want a script for something. The code_writer can write the script, but to test that script it needs a nested chat with a code_runner agent (without LLM, of course) to verify the output and show the user. Sure, there is an option for a group chat where conversation patterns are cyclic (as below)
User_Proxy > Code_Writer > Code_Tester: Rinse and Repeat
But end-users might want the experience to be more conversational, where they can converse with the Code_Writer a little more before sending it to do the work.~

EG.2
Let's say I want to know how which farmlands to invest in based on satellite images and historical weather conditions. I would have an agent to plan out investment strategies (Planner_Agent) speaking to an Executor_Agent agent that will create the automation to do the calculations based on those strategies. However, the agent that develops the straategy realises that its data is incomplete, something the developer did not know. Therefore, since the developer didn'tknow this, the agent workflow they created only has 2 agents, the Planner_Agent and the Executor_Agent. The developer does not know it yet, but the Execturo_Agent will need a Data_Acquisition_Agent to go out and collect more data. I'm basically refering to a system that can identify its own limitations and write add-ons for itself.

The example above is something I personaly faced because i wanted to leverage Autogen's pre-existing support for code execution and peer-to-peer to build an intelligent hive that would take an instruction from the top and autonomously "run-wild" to get it done.

One a personal note, I feel like "pre-setting" the conversation patterns during runtime makes applications built with it feel more like a Zapier automation workflow instead of an intelligent app that truly makes use of the potential of LLMS. To me, it is comparable to giving someone a Jeep and only telling them to drive it on nice flat paved roads when a Jeep is already built to handle rough terrain. 

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've included any doc changes needed for https://autogenhub.github.io/autogen/. See https://autogenhub.github.io/autogen/docs/Contribute#documentation to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
